### PR TITLE
Update utf.md

### DIFF
--- a/wiki/utf.md
+++ b/wiki/utf.md
@@ -31,7 +31,7 @@ Usually 44 bytes
 |-|-|-|-|
 0x00  | uint32  | Next sibling offset  | 
 0x04  | uint32  | Dictionary name offset  | 
-0x08  | uint32  | Entry type  | Directory (0x10) or file (0x80) (see: Win32 API dwFileAttributes)
+0x08  | uint8  | Entry type  | Directory (0x10) or file (0x80) (see: Win32 API dwFileAttributes)
 0x0C  | uint32  | Sharing attributes  | Ignored - Set to zero
 0x10  | uint32  | Child or data offset  | Offset to child entry if type is 0x80 or to data if type is 0x10
 0x14  | uint32  | Allocated data size  | Allocated data byte length.


### PR DESCRIPTION
Only the first byte of the "Entry type" parameter is used to distinguish between branches and leaves. An Entry can be valid even if not all of the subsequent three bytes are zero, as is the case in some vanilla files.